### PR TITLE
fix: order of events on events subpage

### DIFF
--- a/mixins/sortDates.js
+++ b/mixins/sortDates.js
@@ -1,0 +1,14 @@
+export default {
+  methods: {
+    sortDatesChronologically (dates) {
+      return dates.sort((a, b) => {
+        return new Date(a.date) - new Date(b.date);
+      })
+    },
+    sortDatesReverseChronologically (dates) {
+      return dates.sort((a, b) => {
+        return new Date(b.date) - new Date(a.date);
+      })
+    }
+  }
+}

--- a/pages/all_events.vue
+++ b/pages/all_events.vue
@@ -72,9 +72,12 @@
 
     import Navigation from '../components/Navigation.vue';
 	import Footer from '../components/Footer.vue';
-	import Matomo from '../components/Matomo.vue';
+    import Matomo from '../components/Matomo.vue';
+    
+    import sortDates from '../mixins/sortDates.js';
 
     export default {
+        mixins: [ sortDates ],
         components: {
 			Navigation,
 			Footer,
@@ -139,8 +142,11 @@
                     this.data.push(obj);
                 })
 
-                this.dataUpcoming = this.filterData(this.data, true).sort((a, b) => new Date(a.date) - new Date(b.date));
-                this.dataPast = this.filterData(this.data, false).sort((a, b) => new Date(b.date) - new Date(a.date));
+                this.dataUpcoming = this.filterData(this.data, true);
+                this.dataPast = this.filterData(this.data, false);
+
+                this.dataUpcoming = this.sortDatesChronologically(this.dataUpcoming);
+                this.dataPast = this.sortDatesReverseChronologically(this.dataPast);
             })
         },
         methods: {

--- a/pages/all_events.vue
+++ b/pages/all_events.vue
@@ -139,10 +139,8 @@
                     this.data.push(obj);
                 })
 
-                this.data = this.data.sort((a,b) => { return new Date(b.date) - new Date(a.date) });
-
-                this.dataUpcoming = this.filterData(this.data, true);
-                this.dataPast = this.filterData(this.data, false);
+                this.dataUpcoming = this.filterData(this.data, true).sort((a, b) => new Date(a.date) - new Date(b.date));
+                this.dataPast = this.filterData(this.data, false).sort((a, b) => new Date(b.date) - new Date(a.date));
             })
         },
         methods: {

--- a/pages/all_events_en.vue
+++ b/pages/all_events_en.vue
@@ -72,9 +72,12 @@
 
     import Navigation from '../components/Navigation.vue';
 	import Footer from '../components/Footer.vue';
-	import Matomo from '../components/Matomo.vue';
+    import Matomo from '../components/Matomo.vue';
+    
+    import sortDates from '../mixins/sortDates.js';
     
     export default {
+        mixins: [ sortDates ],
         components: {
 			Navigation,
 			Footer,
@@ -139,8 +142,11 @@
                     this.data.push(obj);
                 })
 
-                this.dataUpcoming = this.filterData(this.data, true).sort((a, b) => new Date(a.date) - new Date(b.date));
-                this.dataPast = this.filterData(this.data, false).sort((a, b) => new Date(b.date) - new Date(a.date));
+                this.dataUpcoming = this.filterData(this.data, true);
+                this.dataPast = this.filterData(this.data, false);
+
+                this.dataUpcoming = this.sortDatesChronologically(this.dataUpcoming);
+                this.dataPast = this.sortDatesReverseChronologically(this.dataPast);
             })      
         }, 
         methods: {

--- a/pages/all_events_en.vue
+++ b/pages/all_events_en.vue
@@ -139,10 +139,8 @@
                     this.data.push(obj);
                 })
 
-                this.data = this.data.sort((a,b) => { return new Date(b.date) - new Date(a.date) });
-
-                this.dataUpcoming = this.filterData(this.data, true);
-                this.dataPast = this.filterData(this.data, false);
+                this.dataUpcoming = this.filterData(this.data, true).sort((a, b) => new Date(a.date) - new Date(b.date));
+                this.dataPast = this.filterData(this.data, false).sort((a, b) => new Date(b.date) - new Date(a.date));
             })      
         }, 
         methods: {


### PR DESCRIPTION
This PR is a quickfix for changing the order of upcoming events on the events subpage.

The upcoming events are now sorted according to this pattern: near future before distant future.

Fixes #26 
