### PR TITLE
fix: project tiles height

### DIFF
--- a/components/Projects.vue
+++ b/components/Projects.vue
@@ -122,6 +122,7 @@
     }
 
     a > article {
+        height: 100%;
         background: white;
         overflow: auto;
         transition: all .25s ease-in-out;

--- a/pages/all_projects.vue
+++ b/pages/all_projects.vue
@@ -150,6 +150,7 @@
 
     .project-wrapper {
         width: 100%;
+        height: 100%;
     }
 
     .content-block {
@@ -200,7 +201,6 @@
         .wrapper-details {
             margin: 15px 20px 20px 15px;
             min-height: 60px;
-            overflow: auto;
 
             p.title {
                 margin-bottom: 0px;

--- a/pages/all_projects_en.vue
+++ b/pages/all_projects_en.vue
@@ -150,6 +150,7 @@
 
     .project-wrapper {
         width: 100%;
+        height: 100%;
     }
 
     .content-block {
@@ -200,7 +201,6 @@
         .wrapper-details {
             margin: 15px 20px 20px 15px;
             min-height: 60px;
-            overflow: auto;
 
             p.title {
                 margin-bottom: 0px;


### PR DESCRIPTION
This PR makes the project tiles/cards span the whole available height in their row.

Fixes #30 and also fixes this for the project subpage.