### PR TITLE
input field placeholder

### DIFF
--- a/assets/content.js
+++ b/assets/content.js
@@ -230,9 +230,9 @@ export const content = {
             'urlunsubscribe': '/newsletter_unsubscribe_de',
             'mandatory': '* Pflichtfeld',
             'form': {
-                name: 'Ihr Name',
+                name: 'Dein Name',
                 language: 'Sprache des Newsletters',
-                mail: 'Ihre E-Mail-Adresse',
+                mail: 'Deine E-Mail-Adresse',
                 button: 'Anmelden',
                 agb: 'Durch Angabe meiner E-Mail-Adresse und Anklicken des Buttons „Anmelden“ erkläre ich mich damit einverstanden, dass das CityLAB Berlin mir regelmäßig Informationen zu den Tätigkeiten, Themen und Veranstaltungen per E-Mail in Form eines Newsletters zuschickt. Umfangreiche Informationen zum Anmelde- und Abmeldeverfahren, dem Versandanbieter und der statistischen Auswertung Ihrer Daten sind in unserer Datenschutzerklärung einsehbar.',
                 unsubscribe: 'Meine Einwilligung kann ich jederzeit hier gegenüber dem CityLAB Berlin <a href="/newsletter_unsubscribe_de">widerrufen</a>.'
@@ -1138,7 +1138,7 @@ export const content = {
             mandatory: '* Mandatory field',
             form: {
                 name: 'Your name',
-                mail: 'Your E-Mail',
+                mail: 'Your e-mail',
                 language: 'Language of the newsletter',
                 button: 'Subscribe',
                 agb: 'By entering my e-mail address and clicking the "Subscribe" button, I agree that the City Berlin may send me regular information on the activities of the CityLAB Berlin, related topics and events by e-mail. Comprehensive information on the registration and unsubscription procedure, the service provider and the statistical evaluation of your data can be found in our Privacy Policy.',

--- a/components/Newsletter.vue
+++ b/components/Newsletter.vue
@@ -19,10 +19,10 @@
 
                             <div class="editable_content" style="text-align:left;">
                                 <div id="4405745" rel="text" class="cr_ipe_item ui-sortable">
-                                <input class="input" id="text4405745" name="1090337" style="margin-bottom:15px;" type="text" value="Name"/>
+                                <input class="input" id="text4405745" name="1090337" style="margin-bottom:15px;" type="text" :placeholder="content[lang]['register']['form']['name']"/>
                             </div>
                             <div id="4405746" rel="email" class="cr_ipe_item ui-sortable musthave" style="margin-bottom:15px;">
-                                <input class="input" id="text4405746" name="email" value="E-mail Adresse *" type="text"/>
+                                <input class="input" id="text4405746" name="email" :placeholder="content[lang]['register']['form']['mail']" type="text"/>
                             </div>
 
                             <div id="4405750" rel="checkbox" class="cr_ipe_item ui-sortable musthave" style=" margin-bottom:0px;">


### PR DESCRIPTION


I noticed that the newsletter section on the index page has default text that is not getting cleared when the user clicks into the input fields. This PR suggests fixes. 

- adds placeholder tag to newsletter input field so that users do not have to delete the placeholder text anymore
- implements content.js DE & EN localization for name and email input fields in newsletter
- changed „Ihre“ to „Deine“ for input field DE since the rest of the index addresses user like this
- changed „E-Mail“ to „e-mail“ for EN
- likely fixes nuxt error that happens when input field default text values get send

tested on Chrome/Mac (latest), Safari/Mac (latest)