### PR TITLE
fix: hide Handbuch teaser

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -7,7 +7,7 @@
 		<Topics :lang="lang" :content="content" :direct="direct" />
 		<Paragraph :content='content' :lang='lang' topic="collaborate" subtopic="paragraph"/>
 		<Projects :lang="lang" :content="content"/>
-		<HandbuchTeaser :lang="lang" :content="content" />
+		<!-- <HandbuchTeaser :lang="lang" :content="content" /> -->
 		<Teaser :content='content' :lang='lang' id="exhibition" topic="exhibition" subtopic="teaser"/>
 		<Schedule v-if="eventsVisible" :lang="lang" :content="content" :direct="direct" :links="links"/>
 		<Newsletter :lang="lang" :content="content" :direct="direct"/>

--- a/pages/index_en.vue
+++ b/pages/index_en.vue
@@ -7,7 +7,7 @@
 		<Topics :lang="lang" :content="content" :direct="direct" />
 		<Paragraph :content='content' :lang='lang' topic="collaborate" subtopic="paragraph"/>
 		<Projects :lang="lang" :content="content"/>
-		<HandbuchTeaser :lang="lang" :content="content" />
+		<!-- <HandbuchTeaser :lang="lang" :content="content" /> -->
 		<Teaser :content='content' :lang='lang' id="exhibition" topic="exhibition" subtopic="teaser"/>
 		<Schedule v-if="eventsVisible" :lang="lang" :content="content" :direct="direct" :links="links"/>
 		<Newsletter :lang="lang" :content="content" :direct="direct"/>


### PR DESCRIPTION
This PR hides the banners for the Handbuch for now. Should not be displayed on home page yet.