### PR TITLE
fix: sort events upon year change

### DIFF
--- a/pages/all_events.vue
+++ b/pages/all_events.vue
@@ -102,9 +102,13 @@
             },
         },
         watch: {
-            year() {
-                this.dataUpcoming = this.filterData(this.data, true);
-                this.dataPast = this.filterData(this.data, false);
+            year(newValue, previousValue) {                
+                this.dataUpcoming = this.sortDatesChronologically(this.filterData(this.data, true));
+                if (newValue < previousValue) {
+                    this.dataPast = this.sortDatesChronologically(this.filterData(this.data, false));
+                } else {
+                    this.dataPast = this.sortDatesReverseChronologically(this.filterData(this.data, false));
+                }
             }
         },
         mounted() {

--- a/pages/all_events_en.vue
+++ b/pages/all_events_en.vue
@@ -97,9 +97,13 @@
 			}
         },
         watch: {
-            year() {
-                this.dataUpcoming = this.filterData(this.data, true);
-                this.dataPast = this.filterData(this.data, false);
+            year(newValue, previousValue) {                
+                this.dataUpcoming = this.sortDatesChronologically(this.filterData(this.data, true));
+                if (newValue < previousValue) {
+                    this.dataPast = this.sortDatesChronologically(this.filterData(this.data, false));
+                } else {
+                    this.dataPast = this.sortDatesReverseChronologically(this.filterData(this.data, false));
+                }
             }
         },
         computed: {


### PR DESCRIPTION
This PR applies the date sorting function to the `year` watcher in the `all_events` page. This was previously not the case. Now, whenever the year is toggled, the sorting function sorts the **past** dates in the appropriate order, i.e. chronologically for a past year, and reverse-chronologically for the current year.

Fixes #62 