### PR TITLE
add netlify.toml file based config to test removal of sleep 120

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+
+[build]
+  publish = "dist/"
+  # Default build command.
+  command = "npm run generate"


### PR DESCRIPTION
This PR adds a filebased configuration for netlify to test build speed by removing the `sleep 120`

