### PR TITLE
fix(CLAB-8): specify images domain

### DIFF
--- a/pages/events/_event.vue
+++ b/pages/events/_event.vue
@@ -261,7 +261,7 @@ export default {
         {
           hid: "og:image",
           property: "og:image",
-          content: `/images/events/${this.dirname}_social_media.jpg`,
+          content: `https://citylab-berlin.org/images/events/${this.dirname}_social_media.jpg`,
         },
         {
           hid: "og:description",
@@ -307,13 +307,13 @@ export default {
         {
           hid: "twitter:image",
           name: "twitter:image",
-          content: `/images/events/${this.dirname}_social_media.jpg`,
+          content: `https://citylab-berlin.org/images/events/${this.dirname}_social_media.jpg`,
         },
         { hid: "name", itemprop: "name", content: this.socialDescription },
         {
           hid: "image",
           itemprop: "image",
-          content: `/images/events/${this.dirname}_social_media.jpg`,
+          content: `https://citylab-berlin.org/images/events/${this.dirname}_social_media.jpg`,
         },
       ],
     };


### PR DESCRIPTION
This PR addresses the issue that the event pages were not displaying images when shared (via Twitter, for example).

This is fixed by specifying the domain on which the images are hosted (https://citylab-berlin.org)


