### PR TITLE
chore(CLAB-15): spreadsheet URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Along with using [Nuxt.js](https://nuxtjs.org/) the project is structured in `pa
 
 ### Components
 
-The modular blocks that get rendered inside your pages can be found inside `components/`. If you want to add a new component keep in mind to pass the `content` and `lang` as a prop to  Here an example of the basic structure of a component:
+The modular blocks that get rendered inside your pages can be found inside `components/`. If you want to add a new component keep in mind to pass the `content` and `lang` as a prop to Here an example of the basic structure of a component:
 
 ```vue
 <template>
@@ -18,25 +18,26 @@ The modular blocks that get rendered inside your pages can be found inside `comp
 </template>
 
 <script>
-  export default {
-    name: 'name of component',
-    props: ['content', 'lang'],
-    ...
-  }
+export default {
+  name: 'name of component',
+  props: ['content', 'lang'],
+  ...
+}
 </script>
 <style>
-  .wrapper {
-    width: 100%;
-    ...
-  }
+.wrapper {
+  width: 100%;
+  ...;
+}
 </style>
 ```
 
 ## Content
 
-The content of the site is sourced from a `content.js` file located at `assets/` and a [Google Spreadsheet](https://docs.google.com/spreadsheets/d/1rTyfInS6NjTifbru61mWEqICyv9uuMVSSk7NZTABLQc) (that contains multiple tables) which is accessible to the Team of the CityLAB. If you plan to create new subpages for the site that:
+The content of the site is sourced from a `content.js` file located at `assets/` and a [Google Spreadsheet](https://docs.google.com/spreadsheets/d/1xldCara-dp26yWVU8rL7Acig4IHKqtPRtTZX3HYoaA8) (that contains multiple tables) which is accessible to the Team of the CityLAB. If you plan to create new subpages for the site that:
 
 ### Are created once ...
+
 then add these to the `content.js`. This file is contains both english and german content. If you want to add new content for a created page – we call `paragraph` – add the content fields as an `object` nested inside the objects `en` and `de` like this:
 
 ```
@@ -68,27 +69,27 @@ We pass the content `object` as a prop to your component and link the provided k
 </template>
 
 <script>
-  export default {
-    name: 'Paragraph',
-    props: ['content', 'lang'],
-  }
+export default {
+  name: "Paragraph",
+  props: ["content", "lang"],
+};
 </script>
 <style>
-  .wrapper {
-    width: 100%;
-    ...
-  }
+.wrapper {
+  width: 100%;
+  ...;
+}
 </style>
 ```
 
-If you want to provide content that is updated regulary (e.g. Newsletter, Projects, Events, Exhibits) you use the table inside the [Google Spreadsheet](https://docs.google.com/spreadsheets/d/1rTyfInS6NjTifbru61mWEqICyv9uuMVSSk7NZTABLQc) for content that exists in two languages you find a `_en` and `_de` at the name of the table. In the following you find a description of exisiting columns for the existing tables:
+If you want to provide content that is updated regulary (e.g. Newsletter, Projects, Events, Exhibits) you use the table inside the [Google Spreadsheet](https://docs.google.com/spreadsheets/d/1xldCara-dp26yWVU8rL7Acig4IHKqtPRtTZX3HYoaA8) for content that exists in two languages you find a `_en` and `_de` at the name of the table. In the following you find a description of exisiting columns for the existing tables:
 
 ### projects_de and projects_en table
 
-Pls note: select `TRUE` for column *visible* to either enable or disable a project completely
+Pls note: select `TRUE` for column _visible_ to either enable or disable a project completely
 
-| finished  | defaultImg | featured | publisher | dirName | projectName | projectSubline  | projectSubSubline | headlineIntro | contentIntro   | headlineBlockOne | contentBlockOne | headlineBlockTwo | contentBlockTwo | headlineBlockThree | contentBlockThree | headlineBlockFour | contentBlockFour | socialDescription | link | logo |
-| ---------------------------------- | ----------------------------------------------- | ----------------------------------------------- | ----------------- | -------- | --------------- | --------------- | ---------------------- | ------------------------ | ----------------------- | ------------------------- | -------------------------------- | ------------------------ | ------------------------------ | ------------------------- | -------------------------------- | ----------------------- | ------------------------------ | ------------------------------------------------------------- | ------------------------------------------------- | -------------------------------------------------- |
+| finished                             | defaultImg                                      | featured                                        | publisher         | dirName  | projectName     | projectSubline  | projectSubSubline      | headlineIntro            | contentIntro            | headlineBlockOne          | contentBlockOne                  | headlineBlockTwo         | contentBlockTwo                | headlineBlockThree        | contentBlockThree                | headlineBlockFour       | contentBlockFour               | socialDescription                                             | link                                              | logo                                               |
+| ------------------------------------ | ----------------------------------------------- | ----------------------------------------------- | ----------------- | -------- | --------------- | --------------- | ---------------------- | ------------------------ | ----------------------- | ------------------------- | -------------------------------- | ------------------------ | ------------------------------ | ------------------------- | -------------------------------- | ----------------------- | ------------------------------ | ------------------------------------------------------------- | ------------------------------------------------- | -------------------------------------------------- |
 | Defines which status the project has | Sets defaultImg if no other images are provided | Adds project to featured section at start pages | Name of publisher | url path | name of project | project subline | second project subline | title of first paragraph | text of first paragraph | title of second paragraph | description of seconds paragraph | title of third paragraph | description of third paragraph | title of fourth paragraph | descpription of fourth paragraph | title of fifth pargraph | description of fifth paragraph | text that is visible at social tiles, when the page is shared | url where the link – if provided – is pointing to | set to TRUE or FALSE is a logo should be displayed |
 
 ### events table
@@ -98,6 +99,7 @@ Pls note: select `TRUE` for column *visible* to either enable or disable a proje
 | Defines, if the event is visible | Set the format of event, e.g. workshop, meetup | TRUE or FALSE defines if calendar import is available | set language of event: de, end | url path | set date in following format: YYYY-MM-DD | set start time | set end time | creates automatic date format | set the name of the event | set subline of event | set second subline of event | title of first paragraph | text of first paragraph | title of second paragraph | description of seconds paragraph | title of third paragraph | description of third paragraph | title of fourth paragraph | descpription of fourth paragraph | title of fifth pargraph | description of fifth paragraph | website url in summary box | phone number in summary box | date of event in summary box | organiser in summary box | e-mail in summary box | address in summary box | registration link if existing | text that is visible at social tiles, when the page is shared | set to TRUE or FALSE is a logo should be displayed |
 
 ### exhibits_de and exhibits_en
+
 | visible                            | exhibitName          | exhibitPublisher                            | publisherLink                             | exhibitDescription                    | exhibitDescriptionLong                | imgName                  | date                                  |
 | ---------------------------------- | -------------------- | ------------------------------------------- | ----------------------------------------- | ------------------------------------- | ------------------------------------- | ------------------------ | ------------------------------------- |
 | Defines, if the project is visible | title of the exhibit | author name of exhibit, separated by comma! | links of the authors, separated by comma! | short description text of the exhibit | long description texts of the exhibit | image name e.g: name.jpg | Date in the followin format: Mai 2020 |
@@ -119,14 +121,15 @@ All imagery, logos etc. are located at `static/images/...`. If you want to add i
 Beyond find the naming conventions to supply your page with `hero` or `social_media` images:
 
 ### Events:
+
 ```
 directoryName_hero.jpg
 directoryName_social_media.jpg
 directoryName_logo.jpg (optional)
 ```
 
-
 ### Projects:
+
 ```
 directoryName_hero.jpg
 directoryName_social_media.jpg
@@ -139,21 +142,20 @@ directoryName_logo.jpg (optional)
 
 Hero images should have a resolution of **1880px x 940px** and are required to create a new event. If you don't have any software to crop your images you can use this [Online Photo Editor](https://www.befunky.com/create/crop-photo/).
 
-Please use the following naming convention: ```dirname_hero.jpg```.
+Please use the following naming convention: `dirname_hero.jpg`.
 
 ### Images for Social media
 
 Social media images should have a resolution of **1086px x 573px** and are required to create a new event.
-Please use the following naming convention: ```dirname_social_media.jpg```.
-
+Please use the following naming convention: `dirname_social_media.jpg`.
 
 ## Update site
 
-This site is deployed by Netlify (Net-liff-eye). A push to ```master``` will automatically update the site and set live. If you have bigger updates, please create a new branch and merge them later.
+This site is deployed by Netlify (Net-liff-eye). A push to `master` will automatically update the site and set live. If you have bigger updates, please create a new branch and merge them later.
 
 ## Get started:
 
-``` bash
+```bash
 # install dependencies
 $ npm install
 

--- a/assets/content.js
+++ b/assets/content.js
@@ -7,10 +7,6 @@ export const content = {
   jobs,
   announcements,
   resources,
-  config: {
-    sheetUrlEvents:
-      "https://spreadsheets.google.com/feeds/list/1OB2kDr4rAyGZ_LuntV1ao7FeA4_vZgP95arR5RGk7M4/od6/public/values?alt=json",
-  },
   de: {
     otherevents: [
       {

--- a/components/Projects.vue
+++ b/components/Projects.vue
@@ -96,7 +96,7 @@ export default {
   },
   created() {
     // TODO: example for wrapping it
-    const sheetUrl = `https://spreadsheets.google.com/feeds/list/1rTyfInS6NjTifbru61mWEqICyv9uuMVSSk7NZTABLQc/${this.sheetId}/public/values?alt=json`;
+    const sheetUrl = `https://spreadsheets.google.com/feeds/list/1xldCara-dp26yWVU8rL7Acig4IHKqtPRtTZX3HYoaA8/${this.sheetId}/public/values?alt=json`;
     const responseHandler = (res) => {
       let entries = res.data.feed.entry;
       this.entries = entries;

--- a/components/Schedule.vue
+++ b/components/Schedule.vue
@@ -139,7 +139,7 @@ export default {
     // TODO: wrap that
     axios
       .get(
-        `https://spreadsheets.google.com/feeds/list/1rTyfInS6NjTifbru61mWEqICyv9uuMVSSk7NZTABLQc/3/public/values?alt=json`
+        `https://spreadsheets.google.com/feeds/list/1xldCara-dp26yWVU8rL7Acig4IHKqtPRtTZX3HYoaA8/3/public/values?alt=json`
       )
       .then((res) => {
         let entries = res.data.feed.entry;

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -9,13 +9,13 @@ async function dynamicRoutes() {
     const result = axios
       .all([
         axios.get(
-          "https://spreadsheets.google.com/feeds/list/1rTyfInS6NjTifbru61mWEqICyv9uuMVSSk7NZTABLQc/3/public/values?alt=json"
+          "https://spreadsheets.google.com/feeds/list/1xldCara-dp26yWVU8rL7Acig4IHKqtPRtTZX3HYoaA8/3/public/values?alt=json"
         ), // events
         axios.get(
-          "https://spreadsheets.google.com/feeds/list/1rTyfInS6NjTifbru61mWEqICyv9uuMVSSk7NZTABLQc/1/public/values?alt=json"
+          "https://spreadsheets.google.com/feeds/list/1xldCara-dp26yWVU8rL7Acig4IHKqtPRtTZX3HYoaA8/1/public/values?alt=json"
         ), // projects
         axios.get(
-          "https://spreadsheets.google.com/feeds/list/1rTyfInS6NjTifbru61mWEqICyv9uuMVSSk7NZTABLQc/2/public/values?alt=json"
+          "https://spreadsheets.google.com/feeds/list/1xldCara-dp26yWVU8rL7Acig4IHKqtPRtTZX3HYoaA8/2/public/values?alt=json"
         ), // projects_en
       ])
       .then(

--- a/pages/all_events.vue
+++ b/pages/all_events.vue
@@ -145,7 +145,7 @@ export default {
 
     axios
       .get(
-        `https://spreadsheets.google.com/feeds/list/1rTyfInS6NjTifbru61mWEqICyv9uuMVSSk7NZTABLQc/3/public/values?alt=json`
+        `https://spreadsheets.google.com/feeds/list/1xldCara-dp26yWVU8rL7Acig4IHKqtPRtTZX3HYoaA8/3/public/values?alt=json`
       )
       .then((res) => {
         let entries = res.data.feed.entry;

--- a/pages/all_events_en.vue
+++ b/pages/all_events_en.vue
@@ -141,7 +141,7 @@ export default {
 
     axios
       .get(
-        `https://spreadsheets.google.com/feeds/list/1rTyfInS6NjTifbru61mWEqICyv9uuMVSSk7NZTABLQc/3/public/values?alt=json`
+        `https://spreadsheets.google.com/feeds/list/1xldCara-dp26yWVU8rL7Acig4IHKqtPRtTZX3HYoaA8/3/public/values?alt=json`
       )
       .then((res) => {
         let entries = res.data.feed.entry;

--- a/pages/all_exhibits.vue
+++ b/pages/all_exhibits.vue
@@ -269,7 +269,7 @@ export default {
 
     axios
       .get(
-        `https://spreadsheets.google.com/feeds/list/1rTyfInS6NjTifbru61mWEqICyv9uuMVSSk7NZTABLQc/4/public/values?alt=json`
+        `https://spreadsheets.google.com/feeds/list/1xldCara-dp26yWVU8rL7Acig4IHKqtPRtTZX3HYoaA8/4/public/values?alt=json`
       )
       .then((res) => {
         let entries = res.data.feed.entry;

--- a/pages/all_exhibits_en.vue
+++ b/pages/all_exhibits_en.vue
@@ -269,7 +269,7 @@ export default {
 
     axios
       .get(
-        `https://spreadsheets.google.com/feeds/list/1rTyfInS6NjTifbru61mWEqICyv9uuMVSSk7NZTABLQc/5/public/values?alt=json`
+        `https://spreadsheets.google.com/feeds/list/1xldCara-dp26yWVU8rL7Acig4IHKqtPRtTZX3HYoaA8/5/public/values?alt=json`
       )
       .then((res) => {
         let entries = res.data.feed.entry;

--- a/pages/all_projects.vue
+++ b/pages/all_projects.vue
@@ -140,7 +140,7 @@ export default {
 
     axios
       .get(
-        `https://spreadsheets.google.com/feeds/list/1rTyfInS6NjTifbru61mWEqICyv9uuMVSSk7NZTABLQc/1/public/values?alt=json`
+        `https://spreadsheets.google.com/feeds/list/1xldCara-dp26yWVU8rL7Acig4IHKqtPRtTZX3HYoaA8/1/public/values?alt=json`
       )
       .then((res) => {
         let entries = res.data.feed.entry;

--- a/pages/all_projects_en.vue
+++ b/pages/all_projects_en.vue
@@ -140,7 +140,7 @@ export default {
 
     axios
       .get(
-        `https://spreadsheets.google.com/feeds/list/1rTyfInS6NjTifbru61mWEqICyv9uuMVSSk7NZTABLQc/2/public/values?alt=json`
+        `https://spreadsheets.google.com/feeds/list/1xldCara-dp26yWVU8rL7Acig4IHKqtPRtTZX3HYoaA8/2/public/values?alt=json`
       )
       .then((res) => {
         let entries = res.data.feed.entry;

--- a/pages/events/_event.vue
+++ b/pages/events/_event.vue
@@ -596,7 +596,7 @@ END:VCALENDAR`;
 
     axios
       .get(
-        `https://spreadsheets.google.com/feeds/list/1rTyfInS6NjTifbru61mWEqICyv9uuMVSSk7NZTABLQc/3/public/values?alt=json`
+        `https://spreadsheets.google.com/feeds/list/1xldCara-dp26yWVU8rL7Acig4IHKqtPRtTZX3HYoaA8/3/public/values?alt=json`
       )
       .then((res) => {
         // set event entry to data which matches with dirname

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -4,7 +4,7 @@
       :lang="lang"
       :content="content"
       :direct="direct"
-      :anchorTags="true"
+      :anchor-tags="true"
     />
     <TeaserIntro
       :content="content"
@@ -12,9 +12,6 @@
       topic="hero"
       subtopic="intro"
     />
-    <!-- <Announcements :lang="lang" /> -->
-    <!-- <Hero :lang="lang" :content="content" :direct="direct"/> -->
-    <!-- <Ticker :lang="lang" :content="content" /> -->
     <SmartcityParagraph :lang="lang" />
     <Topics :lang="lang" :content="content" :direct="direct" />
     <Paragraph
@@ -34,11 +31,11 @@
     />
     <Schedule :lang="lang" :content="content" :direct="direct" :links="links" />
     <Newsletter :lang="lang" :content="content" :direct="direct" />
-    <!-- <Partners :lang="lang" :content="content" :direct="direct"/> -->
-    <!-- <Cta :lang="lang" :content="content"/> -->
     <Footer :lang="lang" :content="content" />
 
-    <button @click="topFunction()" id="myBtn" class="arrow-up top">↑</button>
+    <button id="myBtn" class="arrow-up top" @click="topFunction()">
+      ↑
+    </button>
   </div>
 </template>
 
@@ -48,22 +45,16 @@ import { links } from "../assets/links.js";
 
 import Navigation from "../components/Navigation.vue";
 import Footer from "../components/Footer.vue";
-import Cta from "../components/Cta.vue";
-// import Ticker from "../components/Ticker.vue";
 import Teaser from "../components/Teaser.vue";
 import Topics from "../components/Topics.vue";
 import TeaserIntro from "../components/TeaserIntro.vue";
-import Partners from "../components/Partners.vue";
 import Projects from "../components/Projects.vue";
 import Schedule from "../components/Schedule.vue";
 import Newsletter from "../components/Newsletter.vue";
 import Paragraph from "../components/Paragraph.vue";
 import SmartcityParagraph from "../components/SmartcityParagraph.vue";
-// import Announcements from "../components/Announcements.vue";
 import HandbuchTeaser from "../components/HandbuchTeaser.vue";
-import Button from "../components/Button.vue";
 
-import axios from "axios";
 import { mapState } from "vuex";
 
 import { faArrowAltCircleUp } from "@fortawesome/free-solid-svg-icons";
@@ -71,16 +62,11 @@ import { faArrowAltCircleUp } from "@fortawesome/free-solid-svg-icons";
 export default {
   components: {
     Navigation,
-    Cta,
     Schedule,
     Paragraph,
     SmartcityParagraph,
-    // Announcements,
-    // Ticker,
-    Button,
     Footer,
     Topics,
-    Partners,
     TeaserIntro,
     Teaser,
     Projects,
@@ -103,6 +89,25 @@ export default {
     },
     ...mapState(["offset"]),
   },
+  mounted() {
+    if (process.browser) {
+      window.addEventListener("hashchange", () => {
+        if (!this.offset) {
+          window.scrollTo(window.scrollX, window.scrollY - 75);
+          this.setOffset(true);
+        } else if (this.offset) {
+          window.scrollTo(window.scrollX, window.scrollY);
+        }
+      });
+
+      window.addEventListener("scroll", this.handleScroll);
+    }
+  },
+  destroyed() {
+    if (process.browser) {
+      window.removeEventListener("scroll", this.handleScroll);
+    }
+  },
   methods: {
     handleScroll() {
       this.scrollFunction();
@@ -124,26 +129,6 @@ export default {
     setOffset(boolean) {
       this.$store.dispatch("SET_OFFSET", boolean);
     },
-  },
-  mounted() {
-    if (process.browser) {
-      window.addEventListener("hashchange", () => {
-        if (!this.offset) {
-          window.scrollTo(window.scrollX, window.scrollY - 75);
-          this.setOffset(true);
-        } else if (this.offset) {
-          window.scrollTo(window.scrollX, window.scrollY);
-        }
-      });
-
-      window.addEventListener("scroll", this.handleScroll);
-    }
-    const test = this;
-  },
-  destroyed() {
-    if (process.browser) {
-      window.removeEventListener("scroll", this.handleScroll);
-    }
   },
 };
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -32,13 +32,7 @@
       topic="exhibition"
       subtopic="teaser"
     />
-    <Schedule
-      v-if="eventsVisible"
-      :lang="lang"
-      :content="content"
-      :direct="direct"
-      :links="links"
-    />
+    <Schedule :lang="lang" :content="content" :direct="direct" :links="links" />
     <Newsletter :lang="lang" :content="content" :direct="direct" />
     <!-- <Partners :lang="lang" :content="content" :direct="direct"/> -->
     <!-- <Cta :lang="lang" :content="content"/> -->
@@ -103,41 +97,9 @@ export default {
       obj: [],
     };
   },
-  beforeCreate() {
-    // TODO: wrap that
-
-    axios
-      .get(
-        `https://spreadsheets.google.com/feeds/list/1OB2kDr4rAyGZ_LuntV1ao7FeA4_vZgP95arR5RGk7M4/od6/public/values?alt=json`
-      )
-      .then((res) => {
-        let entries = res.data.feed.entry;
-
-        this.entries = entries;
-
-        entries.forEach((entry) => {
-          let obj = {
-            time: entry.gsx$datetime.$t,
-            title: entry.gsx$eventname.$t,
-            visible: entry.gsx$visible.$t,
-          };
-          this.obj.push(obj);
-        });
-      });
-  },
   computed: {
     arrowUp() {
       return faArrowAltCircleUp;
-    },
-    eventsVisible() {
-      let val = false;
-      this.obj.forEach((entry) => {
-        if (entry.visible == "TRUE") {
-          val = true;
-        }
-      });
-
-      return val;
     },
     ...mapState(["offset"]),
   },

--- a/pages/index_en.vue
+++ b/pages/index_en.vue
@@ -4,7 +4,7 @@
       :lang="lang"
       :content="content"
       :direct="direct"
-      :anchorTags="true"
+      :anchor-tags="true"
     />
     <TeaserIntro
       :content="content"
@@ -12,12 +12,8 @@
       topic="hero"
       subtopic="intro"
     />
-    <!-- <Announcements :lang="lang" /> -->
-
-    <!-- <Hero :lang="lang" :content="content" :direct="direct"/> -->
     <SmartcityParagraph :lang="lang" />
 
-    <!-- <Ticker :lang="lang" :content="content" /> -->
     <Topics :lang="lang" :content="content" :direct="direct" />
     <Paragraph
       :content="content"
@@ -28,19 +24,19 @@
     <Projects :lang="lang" :content="content" />
     <HandbuchTeaser :lang="lang" :content="content" />
     <Teaser
+      id="exhibition"
       :content="content"
       :lang="lang"
-      id="exhibition"
       topic="exhibition"
       subtopic="teaser"
     />
     <Schedule :lang="lang" :content="content" :direct="direct" :links="links" />
     <Newsletter :lang="lang" :content="content" :direct="direct" />
-    <!-- <Partners :lang="lang" :content="content" :direct="direct"/> -->
-    <!-- <Cta :lang="lang" :content="content"/> -->
     <Footer :lang="lang" :content="content" />
 
-    <button @click="topFunction()" id="myBtn" class="arrow-up top">↑</button>
+    <button id="myBtn" class="arrow-up top" @click="topFunction()">
+      ↑
+    </button>
   </div>
 </template>
 
@@ -50,22 +46,17 @@ import { links } from "../assets/links.js";
 
 import Navigation from "../components/Navigation.vue";
 import Footer from "../components/Footer.vue";
-import Cta from "../components/Cta.vue";
 import Teaser from "../components/Teaser.vue";
 import Topics from "../components/Topics.vue";
 import TeaserIntro from "../components/TeaserIntro.vue";
-import Partners from "../components/Partners.vue";
-// import Ticker from "../components/Ticker.vue";
 import Projects from "../components/Projects.vue";
 import Schedule from "../components/Schedule.vue";
 import Newsletter from "../components/Newsletter.vue";
 import Paragraph from "../components/Paragraph.vue";
 import SmartcityParagraph from "../components/SmartcityParagraph.vue";
-// import Announcements from "../components/Announcements.vue";
 
 import HandbuchTeaser from "../components/HandbuchTeaser.vue";
 
-import axios from "axios";
 import { mapState } from "vuex";
 
 import { faArrowAltCircleUp } from "@fortawesome/free-solid-svg-icons";
@@ -73,15 +64,11 @@ import { faArrowAltCircleUp } from "@fortawesome/free-solid-svg-icons";
 export default {
   components: {
     Navigation,
-    Cta,
     Schedule,
     Paragraph,
     SmartcityParagraph,
-    // Announcements,
-    // Ticker,
     Footer,
     Topics,
-    Partners,
     TeaserIntro,
     Teaser,
     Projects,
@@ -104,6 +91,25 @@ export default {
     },
     ...mapState(["offset"]),
   },
+  mounted() {
+    if (process.browser) {
+      window.addEventListener("hashchange", () => {
+        if (!this.offset) {
+          window.scrollTo(window.scrollX, window.scrollY - 75);
+          this.setOffset(true);
+        } else if (this.offset) {
+          window.scrollTo(window.scrollX, window.scrollY);
+        }
+      });
+
+      window.addEventListener("scroll", this.handleScroll);
+    }
+  },
+  destroyed() {
+    if (process.browser) {
+      window.removeEventListener("scroll", this.handleScroll);
+    }
+  },
   methods: {
     handleScroll() {
       this.scrollFunction();
@@ -125,25 +131,6 @@ export default {
     setOffset(boolean) {
       this.$store.dispatch("SET_OFFSET", boolean);
     },
-  },
-  mounted() {
-    if (process.browser) {
-      window.addEventListener("hashchange", () => {
-        if (!this.offset) {
-          window.scrollTo(window.scrollX, window.scrollY - 75);
-          this.setOffset(true);
-        } else if (this.offset) {
-          window.scrollTo(window.scrollX, window.scrollY);
-        }
-      });
-
-      window.addEventListener("scroll", this.handleScroll);
-    }
-  },
-  destroyed() {
-    if (process.browser) {
-      window.removeEventListener("scroll", this.handleScroll);
-    }
   },
 };
 </script>

--- a/pages/index_en.vue
+++ b/pages/index_en.vue
@@ -34,13 +34,7 @@
       topic="exhibition"
       subtopic="teaser"
     />
-    <Schedule
-      v-if="eventsVisible"
-      :lang="lang"
-      :content="content"
-      :direct="direct"
-      :links="links"
-    />
+    <Schedule :lang="lang" :content="content" :direct="direct" :links="links" />
     <Newsletter :lang="lang" :content="content" :direct="direct" />
     <!-- <Partners :lang="lang" :content="content" :direct="direct"/> -->
     <!-- <Cta :lang="lang" :content="content"/> -->
@@ -104,41 +98,9 @@ export default {
       obj: [],
     };
   },
-  beforeCreate() {
-    // TODO: wrap that
-
-    axios
-      .get(
-        `https://spreadsheets.google.com/feeds/list/1OB2kDr4rAyGZ_LuntV1ao7FeA4_vZgP95arR5RGk7M4/od6/public/values?alt=json`
-      )
-      .then((res) => {
-        let entries = res.data.feed.entry;
-
-        this.entries = entries;
-
-        entries.forEach((entry) => {
-          let obj = {
-            time: entry.gsx$datetime.$t,
-            title: entry.gsx$eventname.$t,
-            visible: entry.gsx$visible.$t,
-          };
-          this.obj.push(obj);
-        });
-      });
-  },
   computed: {
     arrowUp() {
       return faArrowAltCircleUp;
-    },
-    eventsVisible() {
-      let val = false;
-      this.obj.forEach((entry) => {
-        if (entry.visible == "TRUE") {
-          val = true;
-        }
-      });
-
-      return val;
     },
     ...mapState(["offset"]),
   },

--- a/pages/newsletter_archive.vue
+++ b/pages/newsletter_archive.vue
@@ -108,7 +108,7 @@ export default {
       // TODO: wrap that
 
       let url =
-        `https://spreadsheets.google.com/feeds/list/1rTyfInS6NjTifbru61mWEqICyv9uuMVSSk7NZTABLQc/` +
+        `https://spreadsheets.google.com/feeds/list/1xldCara-dp26yWVU8rL7Acig4IHKqtPRtTZX3HYoaA8/` +
         sheetPageNumber +
         `/public/values?alt=json`;
       axios.get(url).then((res) => {

--- a/pages/newsletter_archive_en.vue
+++ b/pages/newsletter_archive_en.vue
@@ -106,7 +106,7 @@ export default {
       // TODO: wrap that
 
       let url =
-        `https://spreadsheets.google.com/feeds/list/1rTyfInS6NjTifbru61mWEqICyv9uuMVSSk7NZTABLQc/` +
+        `https://spreadsheets.google.com/feeds/list/1xldCara-dp26yWVU8rL7Acig4IHKqtPRtTZX3HYoaA8/` +
         sheetPageNumber +
         `/public/values?alt=json`;
       axios.get(url).then((res) => {

--- a/pages/projects/_project.vue
+++ b/pages/projects/_project.vue
@@ -288,7 +288,7 @@ export default {
 
     axios
       .get(
-        `https://spreadsheets.google.com/feeds/list/1rTyfInS6NjTifbru61mWEqICyv9uuMVSSk7NZTABLQc/1/public/values?alt=json`
+        `https://spreadsheets.google.com/feeds/list/1xldCara-dp26yWVU8rL7Acig4IHKqtPRtTZX3HYoaA8/1/public/values?alt=json`
       )
       .then((res) => {
         // set event entry to data which matches with dirname

--- a/pages/projects_en/_project.vue
+++ b/pages/projects_en/_project.vue
@@ -307,7 +307,7 @@ export default {
 
     axios
       .get(
-        `https://spreadsheets.google.com/feeds/list/1rTyfInS6NjTifbru61mWEqICyv9uuMVSSk7NZTABLQc/2/public/values?alt=json`
+        `https://spreadsheets.google.com/feeds/list/1xldCara-dp26yWVU8rL7Acig4IHKqtPRtTZX3HYoaA8/2/public/values?alt=json`
       )
       .then((res) => {
         // set event entry to data which matches with dirname


### PR DESCRIPTION
This PR updates the spreadsheet URL for events and projects (it was internally necessary to move the spreadsheet to a new Drive). The spreadsheet content remains the exact same, as it was copied from old to new.

In addition, the PR removes a stale spreadsheet (33a1137101f6a8cd102d8c6ef9ea53618fb344b6) that was not relevant for the site.

There is also some cleanup and formatting.

Note: The experimental spreadsheet scraper has not been touched, as it is not in use and probably won't be in the future (cc @ff6347).